### PR TITLE
Update timbre to latest version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :dependencies
   [[aleph "0.4.6"]
    [bidi "2.1.6"]
-   [com.taoensso/timbre "4.10.0"]
+   [com.taoensso/timbre "5.0.1"]
    [environ "1.1.0"]
    [io.prometheus/simpleclient_hotspot "0.5.0"]
    [org.clojure/clojure "1.10.1"]


### PR DESCRIPTION
This change is here to prevent https://github.com/ptaoussanis/timbre/issues/263 from happening when loading the `tx-metrics-callback-handler`. Occurred with Datomic "1.0.6165".

```

14:04:39.186 [clojure-agent-send-off-pool-0] INFO  datomic.process-monitor - {:event :metrics/initializing, :metricsCallback datomic-tx-metrics.core/tx-metrics-callback-handler, :msec 8320.0, :phase :end, :threw clojure.lang.Compiler$CompilerException, :pid 10, :tid 11}
--
  | 14:04:39.197 [clojure-agent-send-off-pool-1] ERROR datomic.process - {:message "Terminating process - Error starting transactor", :pid 10, :tid 16}
  | clojure.lang.Compiler$CompilerException: Syntax error compiling at (clojure/tools/reader/edn.clj:1:1).
  | at clojure.lang.Compiler.load(Compiler.java:7648)
  | at clojure.lang.RT.loadResourceScript(RT.java:381)
  | at clojure.lang.RT.loadResourceScript(RT.java:372)
  | at clojure.lang.RT.load(RT.java:459)
  | at clojure.lang.RT.load(RT.java:424)
  | at clojure.core$load$fn__6839.invoke(core.clj:6126)
  | at clojure.core$load.invokeStatic(core.clj:6125)
  | at clojure.core$load.doInvoke(core.clj:6109)
  | at clojure.lang.RestFn.invoke(RestFn.java:408)
  | at clojure.core$load_one.invokeStatic(core.clj:5908)
  | at clojure.core$load_one.invoke(core.clj:5903)
  | at clojure.core$load_lib$fn__6780.invoke(core.clj:5948)
  | at clojure.core$load_lib.invokeStatic(core.clj:5947)
  | at clojure.core$load_lib.doInvoke(core.clj:5928)
  | at clojure.lang.RestFn.applyTo(RestFn.java:142)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_libs.invokeStatic(core.clj:5985)
  | at clojure.core$load_libs.doInvoke(core.clj:5969)
  | at clojure.lang.RestFn.applyTo(RestFn.java:137)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$require.invokeStatic(core.clj:6007)
  | at clojure.core$require.doInvoke(core.clj:6007)
  | at clojure.lang.RestFn.invoke(RestFn.java:551)
  | at taoensso.encore$eval9867$loading__6721__auto____9868.invoke(encore.clj:1)
  | at taoensso.encore$eval9867.invokeStatic(encore.clj:1)
  | at taoensso.encore$eval9867.invoke(encore.clj:1)
  | at clojure.lang.Compiler.eval(Compiler.java:7177)
  | at clojure.lang.Compiler.eval(Compiler.java:7166)
  | at clojure.lang.Compiler.load(Compiler.java:7636)
  | at clojure.lang.RT.loadResourceScript(RT.java:381)
  | at clojure.lang.RT.loadResourceScript(RT.java:372)
  | at clojure.lang.RT.load(RT.java:459)
  | at clojure.lang.RT.load(RT.java:424)
  | at clojure.core$load$fn__6839.invoke(core.clj:6126)
  | at clojure.core$load.invokeStatic(core.clj:6125)
  | at clojure.core$load.doInvoke(core.clj:6109)
  | at clojure.lang.RestFn.invoke(RestFn.java:408)
  | at clojure.core$load_one.invokeStatic(core.clj:5908)
  | at clojure.core$load_one.invoke(core.clj:5903)
  | at clojure.core$load_lib$fn__6780.invoke(core.clj:5948)
  | at clojure.core$load_lib.invokeStatic(core.clj:5947)
  | at clojure.core$load_lib.doInvoke(core.clj:5928)
  | at clojure.lang.RestFn.applyTo(RestFn.java:142)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_libs.invokeStatic(core.clj:5985)
  | at clojure.core$load_libs.doInvoke(core.clj:5969)
  | at clojure.lang.RestFn.applyTo(RestFn.java:137)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$require.invokeStatic(core.clj:6007)
  | at clojure.core$require.doInvoke(core.clj:6007)
  | at clojure.lang.RestFn.invoke(RestFn.java:457)
  | at taoensso.timbre$eval9454$loading__6721__auto____9455.invoke(timbre.clj:1)
  | at taoensso.timbre$eval9454.invokeStatic(timbre.clj:1)
  | at taoensso.timbre$eval9454.invoke(timbre.clj:1)
  | at clojure.lang.Compiler.eval(Compiler.java:7177)
  | at clojure.lang.Compiler.eval(Compiler.java:7166)
  | at clojure.lang.Compiler.load(Compiler.java:7636)
  | at clojure.lang.RT.loadResourceScript(RT.java:381)
  | at clojure.lang.RT.loadResourceScript(RT.java:372)
  | at clojure.lang.RT.load(RT.java:459)
  | at clojure.lang.RT.load(RT.java:424)
  | at clojure.core$load$fn__6839.invoke(core.clj:6126)
  | at clojure.core$load.invokeStatic(core.clj:6125)
  | at clojure.core$load.doInvoke(core.clj:6109)
  | at clojure.lang.RestFn.invoke(RestFn.java:408)
  | at clojure.core$load_one.invokeStatic(core.clj:5908)
  | at clojure.core$load_one.invoke(core.clj:5903)
  | at clojure.core$load_lib$fn__6780.invoke(core.clj:5948)
  | at clojure.core$load_lib.invokeStatic(core.clj:5947)
  | at clojure.core$load_lib.doInvoke(core.clj:5928)
  | at clojure.lang.RestFn.applyTo(RestFn.java:142)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_libs.invokeStatic(core.clj:5985)
  | at clojure.core$load_libs.doInvoke(core.clj:5969)
  | at clojure.lang.RestFn.applyTo(RestFn.java:137)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$require.invokeStatic(core.clj:6007)
  | at clojure.core$require.doInvoke(core.clj:6007)
  | at clojure.lang.RestFn.invoke(RestFn.java:512)
  | at datomic_tx_metrics.core$eval266$loading__6721__auto____267.invoke(core.clj:1)
  | at datomic_tx_metrics.core$eval266.invokeStatic(core.clj:1)
  | at datomic_tx_metrics.core$eval266.invoke(core.clj:1)
  | at clojure.lang.Compiler.eval(Compiler.java:7177)
  | at clojure.lang.Compiler.eval(Compiler.java:7166)
  | at clojure.lang.Compiler.load(Compiler.java:7636)
  | at clojure.lang.RT.loadResourceScript(RT.java:381)
  | at clojure.lang.RT.loadResourceScript(RT.java:372)
  | at clojure.lang.RT.load(RT.java:459)
  | at clojure.lang.RT.load(RT.java:424)
  | at clojure.core$load$fn__6839.invoke(core.clj:6126)
  | at clojure.core$load.invokeStatic(core.clj:6125)
  | at clojure.core$load.doInvoke(core.clj:6109)
  | at clojure.lang.RestFn.invoke(RestFn.java:408)
  | at clojure.core$load_one.invokeStatic(core.clj:5908)
  | at clojure.core$load_one.invoke(core.clj:5903)
  | at clojure.core$load_lib$fn__6780.invoke(core.clj:5948)
  | at clojure.core$load_lib.invokeStatic(core.clj:5947)
  | at clojure.core$load_lib.doInvoke(core.clj:5928)
  | at clojure.lang.RestFn.applyTo(RestFn.java:142)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_libs.invokeStatic(core.clj:5985)
  | at clojure.core$load_libs.doInvoke(core.clj:5969)
  | at clojure.lang.RestFn.applyTo(RestFn.java:137)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$require.invokeStatic(core.clj:6007)
  | at clojure.core$require.doInvoke(core.clj:6007)
  | at clojure.lang.RestFn.invoke(RestFn.java:408)
  | at datomic.callback$create_callback.invokeStatic(callback.clj:46)
  | at datomic.callback$create_callback.invoke(callback.clj:38)
  | at datomic.process_monitor$metrics_callback$fn__22245.invoke(process_monitor.clj:38)
  | at datomic.process_monitor$metrics_callback.invokeStatic(process_monitor.clj:34)
  | at datomic.process_monitor$metrics_callback.invoke(process_monitor.clj:30)
  | at datomic.process_monitor$fn__22266.invokeStatic(process_monitor.clj:56)
  | at datomic.process_monitor$fn__22266.invoke(process_monitor.clj:55)
  | at clojure.lang.Delay.deref(Delay.java:42)
  | at clojure.core$deref.invokeStatic(core.clj:2320)
  | at clojure.core$deref.invoke(core.clj:2306)
  | at datomic.process_monitor$start_metrics.invokeStatic(process_monitor.clj:70)
  | at datomic.process_monitor$start_metrics.invoke(process_monitor.clj:70)
  | at clojure.lang.Var.invoke(Var.java:380)
  | at datomic.transactor$run_STAR_.invokeStatic(transactor.clj:344)
  | at datomic.transactor$run_STAR_.invoke(transactor.clj:242)
  | at datomic.transactor$run$fn__30046.invoke(transactor.clj:388)
  | at clojure.core$binding_conveyor_fn$fn__5754.invoke(core.clj:2030)
  | at clojure.lang.AFn.call(AFn.java:18)
  | at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  | at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  | at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  | at java.base/java.lang.Thread.run(Thread.java:834)
  | Caused by: java.lang.IllegalAccessError: reader-error does not exist
  | at clojure.core$refer.invokeStatic(core.clj:4249)
  | at clojure.core$refer.doInvoke(core.clj:4217)
  | at clojure.lang.RestFn.applyTo(RestFn.java:139)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_lib.invokeStatic(core.clj:5966)
  | at clojure.core$load_lib.doInvoke(core.clj:5928)
  | at clojure.lang.RestFn.applyTo(RestFn.java:142)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$load_libs.invokeStatic(core.clj:5985)
  | at clojure.core$load_libs.doInvoke(core.clj:5969)
  | at clojure.lang.RestFn.applyTo(RestFn.java:137)
  | at clojure.core$apply.invokeStatic(core.clj:667)
  | at clojure.core$require.invokeStatic(core.clj:6007)
  | at clojure.core$require.doInvoke(core.clj:6007)
  | at clojure.lang.RestFn.invoke(RestFn.java:457)
  | at clojure.tools.reader.edn$eval9875$loading__6721__auto____9876.invoke(edn.clj:9)
  | at clojure.tools.reader.edn$eval9875.invokeStatic(edn.clj:9)
  | at clojure.tools.reader.edn$eval9875.invoke(edn.clj:9)
  | at clojure.lang.Compiler.eval(Compiler.java:7177)
  | at clojure.lang.Compiler.eval(Compiler.java:7166)
  | at clojure.lang.Compiler.load(Compiler.java:7636)
  | ... 128 common frames omitted
```